### PR TITLE
Use `nfsd restart` instead of `nfsd update`

### DIFF
--- a/nfsexports.go
+++ b/nfsexports.go
@@ -178,7 +178,7 @@ func ListAll(exportsFile string) ([]string, error) {
 
 // ReloadDaemon reload NFS daemon
 func ReloadDaemon() error {
-	cmd := exec.Command("sudo", "/sbin/nfsd", "update")
+	cmd := exec.Command("sudo", "/sbin/nfsd", "restart")
 	cmd.Stderr = &bytes.Buffer{}
 
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
launchd starts `/sbin/nfsd` when `/etc/exports` is created (and stops it when it is deleted). See `cat /System/Library/LaunchDaemons/com.apple.nfsd.plist`.

When nfsd is not running, `nfsd update` fails:

```
# rm /etc/exports; sleep 1; touch /etc/exports; sleep 1; /sbin/nfsd update
nfsd: nfsd not running?
```

In my tests it took almost 10s for nfsd to be running again:

```
# rm /etc/exports; sleep 1; touch /etc/exports; for i in $(seq 10); do sleep 1; /sbin/nfsd status; done
nfsd service is enabled
nfsd is not running
nfsd service is enabled
nfsd is not running
nfsd service is enabled
nfsd is not running
nfsd service is enabled
nfsd is not running
nfsd service is enabled
nfsd is not running
nfsd service is enabled
nfsd is not running
nfsd service is enabled
nfsd is not running
nfsd service is enabled
nfsd is not running
nfsd service is enabled
nfsd is running (pid 12367, 8 threads)
nfsd service is enabled
nfsd is running (pid 12367, 8 threads)
```

So using `/sbin/nfsd restart` feels like a safer option for `ReloadDaemon` (and also matches the function name more closely).

I'm now wondering if `Remove` should actually delete `/etc/exports` when there is only whitespace left, to shut down the daemon instead of keeping it running with nothing exported.

It looks like `launchd` will also shut down the daemon automatically, even when you run `/sbin/nfsd restart` without creating `/etc/exports`, so everything would still work as expected:

```
# rm /etc/exports; sleep 1; /sbin/nfsd restart; sleep 10; /sbin/nfsd status
The nfsd service does not appear to be running.
Starting the nfsd service
nfsd service is enabled
nfsd is not running
```

Let me know if you want a PR that deletes `/etc/exports` when the file becomes empty!